### PR TITLE
Fix rec-button closing tag in index

### DIFF
--- a/index.html
+++ b/index.html
@@ -280,7 +280,7 @@
                 <p data-label-id="fullscreen-shot"></p>
                 <div class="controls">
                     <button id="captuer-button" class="button button-gray" data-tooltip-id="captuer-button" data-label-id="captuer-button"></button>
-                    <button id="rec-button" class="button button button-gray" data-tooltip-id="rec-button" data-label-id="rec-button">/button>
+                    <button id="rec-button" class="button button button-gray" data-tooltip-id="rec-button" data-label-id="rec-button"></button>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
- fix malformed closing tag for rec-button in `index.html`

## Testing
- `python3 - <<'PY'
from html.parser import HTMLParser
try:
    HTMLParser().feed(open('index.html', encoding='utf-8').read())
    print('parse ok')
except Exception as e:
    print('parse error', e)
PY`

------
https://chatgpt.com/codex/tasks/task_e_685e63a5f208832cbf4df7aa2e3f2a05